### PR TITLE
Flush queue on test pending

### DIFF
--- a/lib/mochaIntellijReporter.js
+++ b/lib/mochaIntellijReporter.js
@@ -293,6 +293,7 @@ function IntellijReporter(runner) {
 
   runner.on('pending', function (test) {
     executeSafely(function () {
+      finishingQueue.processAll();
       finishTestNode(tree, test, null, finishingQueue);
     });
   });


### PR DESCRIPTION
Hi!
When some test are skipped, mocha-intellij produces error output after tests:

```
mocha-intellij: unexpectedly unprocessed element [object Object]
```

Probably need to flush queue somewhere here.
Here's repo with example https://github.com/losnikitos/intellij-mocha-example
